### PR TITLE
updating random_string & aws_budgets_budget resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-aws-budgets-alerts
 Terraform module which deploys [AWS Budgets](https://aws.amazon.com/aws-cost-management/aws-budgets/) alerts to your AWS account using the Terraform AWS Provider Budgets [resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget)
 
-# Description
+## Description
 
 This Terraform module deploys an AWS Budget alert to send a notification if the actual or forecasted cost has reached a certain limit within a AWS account. You can specify to choose to create an alert for the overall cost of the account or from one of the allowed services;
 
@@ -21,12 +21,13 @@ To create an overall cost alert of the AWS account we need to specify the `overa
 provider "aws" {
   region = "eu-west-2"
 
-  #access_key = "fill if not .aws/credentials or env variables"
-  #secret_key = "fill if not .aws/credentials or env variables"
+  #access_key = "add if not .aws/credentials or env variables"
+  #secret_key = "add if not .aws/credentials or env variables"
 }
 
-module "aws_budgets_monthly_alert" {
-  source = "github.com/sculley/terraform-aws-budgets-alerts"
+module "budgets-alerts" {
+  source  = "sculley/budgets-alerts/aws"
+  version = "1.0.2"
 
   overall_budget_cost_alert_enabled = true
   budget_limit_amount               = "500"
@@ -45,8 +46,9 @@ provider "aws" {
   #secret_key = "fill if not .aws/credentials or env variables"
 }
 
-module "aws_budgets_monthly_alert" {
-  source = "github.com/sculley/terraform-aws-budgets-alerts"
+module "budgets-alerts" {
+  source  = "sculley/budgets-alerts/aws"
+  version = "1.0.2"
 
   service_budget_cost_alert_enabled = true
   budget_limit_amount               = "500"
@@ -74,27 +76,59 @@ Apply the Terraform configuration
 $ terraform apply
 ```
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.22.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.3.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.22.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_budgets_budget.overall_budget_cost_email_notification](https://registry.terraform.io/providers/hashicorp/aws/3.22.0/docs/resources/budgets_budget) | resource |
+| [aws_budgets_budget.service_budget_cost_email_notification](https://registry.terraform.io/providers/hashicorp/aws/3.22.0/docs/resources/budgets_budget) | resource |
+| [random_string.random](https://registry.terraform.io/providers/hashicorp/random/3.3.2/docs/resources/string) | resource |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| overall_budget_cost_alert_enabled | Enable/Disable the overall budget cost alert | `bool` | `false` | yes |
-| service_budget_cost_alert_enabled | Enable/Disable a specific service budget cost alert | `bool` | `false` | yes |
-| budget_limit_amount | The amount for the budget alert. | `string` | `100` | no |
-| budget_limit_unit | The currency used for the budget, such as USD or GB | `string` | `USD` | no |
-| budget_time_unit | The length of time until a budget resets the actual and forecasted spend. Valid values: MONTHLY, QUARTERLY, ANNUALLY | `string` | `MONTHLY` | no |
-| budget_service_filter | An AWS Service to use | `string` | `Amazon Elastic Compute Cloud - Compute` | no |
-| notification_threshold | % Threshold when the notification should be sent. | `string` | `100` | no |
-| notification_type | What kind of budget value to notify on. Can be ACTUAL or FORECASTED | `string` | `FORECASTED` | no |
-| notification_emails | List of email addresses to send budget notifications too | `string` | `""` | yes |
-| cost_type_include_credit | A boolean value whether to include credits in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_discount | Specifies whether a budget includes discounts. | `string` | `"true"` | no |
-| cost_type_include_other_subscription | A boolean value whether to include other subscription costs in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_recurring | A boolean value whether to include recurring costs in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_refund | A boolean value whether to include refunds in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_subscription | A boolean value whether to include subscriptions in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_support | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_tax | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
-| cost_type_include_upfront | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
-| cost_type_use_amortized | Specifies whether a budget uses the amortized rate. | `string` | `"false"` | no |
-| cost_type_use_blended | A boolean value whether to use blended costs in the cost budget. | `string` | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| <a name="input_budget_limit_amount"></a> [budget\_limit\_amount](#input\_budget\_limit\_amount) | The amount for the budget alert. | `string` | `"100"` | no |
+| <a name="input_budget_limit_unit"></a> [budget\_limit\_unit](#input\_budget\_limit\_unit) | The currency used for the budget, such as USD or GB. | `string` | `"USD"` | no |
+| <a name="input_budget_service_filter"></a> [budget\_service\_filter](#input\_budget\_service\_filter) | An AWS Service filter to use when creating a specific service budget alert. | `string` | `"Amazon Elastic Compute Cloud - Compute"` | no |
+| <a name="input_budget_time_unit"></a> [budget\_time\_unit](#input\_budget\_time\_unit) | The length of time until a budget resets the actual and forecasted spend, Valid values: MONTHLY, QUARTERLY, ANNUALLY. | `string` | `"MONTHLY"` | no |
+| <a name="input_cost_type_include_credit"></a> [cost\_type\_include\_credit](#input\_cost\_type\_include\_credit) | A boolean value whether to include credits in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_discount"></a> [cost\_type\_include\_discount](#input\_cost\_type\_include\_discount) | Specifies whether a budget includes discounts. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_other_subscription"></a> [cost\_type\_include\_other\_subscription](#input\_cost\_type\_include\_other\_subscription) | A boolean value whether to include other subscription costs in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_recurring"></a> [cost\_type\_include\_recurring](#input\_cost\_type\_include\_recurring) | A boolean value whether to include recurring costs in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_refund"></a> [cost\_type\_include\_refund](#input\_cost\_type\_include\_refund) | A boolean value whether to include refunds in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_subscription"></a> [cost\_type\_include\_subscription](#input\_cost\_type\_include\_subscription) | A boolean value whether to include subscriptions in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_support"></a> [cost\_type\_include\_support](#input\_cost\_type\_include\_support) | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_tax"></a> [cost\_type\_include\_tax](#input\_cost\_type\_include\_tax) | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_include_upfront"></a> [cost\_type\_include\_upfront](#input\_cost\_type\_include\_upfront) | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
+| <a name="input_cost_type_use_amortized"></a> [cost\_type\_use\_amortized](#input\_cost\_type\_use\_amortized) | Specifies whether a budget uses the amortized rate. | `string` | `"false"` | no |
+| <a name="input_cost_type_use_blended"></a> [cost\_type\_use\_blended](#input\_cost\_type\_use\_blended) | A boolean value whether to use blended costs in the cost budget. | `string` | `"false"` | no |
+| <a name="input_notification_emails"></a> [notification\_emails](#input\_notification\_emails) | List of email addresses to send budget notifications too | `string` | `""` | no |
+| <a name="input_notification_threshold"></a> [notification\_threshold](#input\_notification\_threshold) | Threshold when the notification should be sent | `string` | `100` | no |
+| <a name="input_notification_type"></a> [notification\_type](#input\_notification\_type) | What kind of budget value to notify on. Can be ACTUAL or FORECASTED | `string` | `"FORECASTED"` | no |
+| <a name="input_overall_budget_cost_alert_enabled"></a> [overall\_budget\_cost\_alert\_enabled](#input\_overall\_budget\_cost\_alert\_enabled) | Enable/Disable the overall budget cost alert. | `bool` | `false` | no |
+| <a name="input_service_budget_cost_alert_enabled"></a> [service\_budget\_cost\_alert\_enabled](#input\_service\_budget\_cost\_alert\_enabled) | Enable/Disable a specific service budget cost alert. | `bool` | `false` | no |
+| <a name="input_service_types"></a> [service\_types](#input\_service\_types) | this is not a valid input, this map object is created to generate a shortname for the budget alert rather than using the long name for the service. | `map(string)` | <pre>{<br>  "Amazon ElastiCache": "elasticache",<br>  "Amazon Elastic Compute Cloud - Compute": "ec2",<br>  "Amazon Elasticsearch Service": "elasticsearch",<br>  "Amazon Redshift": "redshift",<br>  "Amazon Relational Database Service": "rds"<br>}</pre> | no |
+
+## Outputs
+
+No outputs.

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "random_string" "random" {
   length = 8
   upper = true
   lower = false
-  number = false
+  numeric = false
   special = false
 }
 

--- a/main.tf
+++ b/main.tf
@@ -69,8 +69,11 @@ resource "aws_budgets_budget" "service_budget_cost_email_notification" {
     use_blended = var.cost_type_use_blended
   }
 
-  cost_filters = {
-    Service =  var.budget_service_filter
+  cost_filter {
+    name = "Service"
+    values = [
+      var.budget_service_filter,
+    ]
   }
 
   notification {

--- a/versions.tf
+++ b/versions.tf
@@ -3,5 +3,6 @@ terraform {
 
   required_providers {
     aws = "3.22.0"
+    random = "3.3.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "3.22.0"
+    aws = "4.22.0"
     random = "3.3.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "4.22.0"
+    aws = ">= 3.22.0, < 4.22.0"
     random = "3.3.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.22.0, < 4.22.0"
     random = "3.3.2"
   }
 }


### PR DESCRIPTION
`random_string` resource has deprecate the `number` input parameter, we have updated to use the new `numeric` parameter.

https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string#numeric

`aws_budgets_budget` resources has deprecated the `cost_filters` input parameter, we have updated to use the new `cost_filter` parameter.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget#cost_filter

The README.md has also been updated to reflect these changes.