### PR TITLE
fix: notification variables for multiple mails

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.22.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.52.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.22.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.52.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Modules
@@ -99,8 +99,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_budgets_budget.overall_budget_cost_email_notification](https://registry.terraform.io/providers/hashicorp/aws/3.22.0/docs/resources/budgets_budget) | resource |
-| [aws_budgets_budget.service_budget_cost_email_notification](https://registry.terraform.io/providers/hashicorp/aws/3.22.0/docs/resources/budgets_budget) | resource |
+| [aws_budgets_budget.overall_budget_cost_email_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget) | resource |
+| [aws_budgets_budget.service_budget_cost_email_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget) | resource |
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/3.3.2/docs/resources/string) | resource |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "budgets-alerts" {
   overall_budget_cost_alert_enabled = true
   budget_limit_amount               = "500"
   notification_type                 = "ACTUAL"
-  notification_emails               = "sam@samculley.co.uk"
+  notification_emails               = ["sam@samculley.co.uk"]
 }
 ```
 
@@ -54,7 +54,7 @@ module "budgets-alerts" {
   budget_limit_amount               = "500"
   budget_service_filter             = "Amazon Relational Database Service"
   notification_type                 = "ACTUAL"
-  notification_emails               = "sam@samculley.co.uk"
+  notification_emails               = ["sam@samculley.co.uk"]
 }
 ```
 
@@ -122,7 +122,7 @@ No modules.
 | <a name="input_cost_type_include_upfront"></a> [cost\_type\_include\_upfront](#input\_cost\_type\_include\_upfront) | A boolean value whether to include support costs in the cost budget. | `string` | `"true"` | no |
 | <a name="input_cost_type_use_amortized"></a> [cost\_type\_use\_amortized](#input\_cost\_type\_use\_amortized) | Specifies whether a budget uses the amortized rate. | `string` | `"false"` | no |
 | <a name="input_cost_type_use_blended"></a> [cost\_type\_use\_blended](#input\_cost\_type\_use\_blended) | A boolean value whether to use blended costs in the cost budget. | `string` | `"false"` | no |
-| <a name="input_notification_emails"></a> [notification\_emails](#input\_notification\_emails) | List of email addresses to send budget notifications too | `string` | `""` | no |
+| <a name="input_notification_emails"></a> [notification\_emails](#input\_notification\_emails) | List of email addresses to send budget notifications to | `list(string)` | `[]` | no |
 | <a name="input_notification_threshold"></a> [notification\_threshold](#input\_notification\_threshold) | Threshold when the notification should be sent | `string` | `100` | no |
 | <a name="input_notification_type"></a> [notification\_type](#input\_notification\_type) | What kind of budget value to notify on. Can be ACTUAL or FORECASTED | `string` | `"FORECASTED"` | no |
 | <a name="input_overall_budget_cost_alert_enabled"></a> [overall\_budget\_cost\_alert\_enabled](#input\_overall\_budget\_cost\_alert\_enabled) | Enable/Disable the overall budget cost alert. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_budgets_budget" "overall_budget_cost_email_notification" {
     threshold                  = var.notification_threshold
     threshold_type             = "PERCENTAGE"
     notification_type          = var.notification_type
-    subscriber_email_addresses = [var.notification_emails]
+    subscriber_email_addresses = var.notification_emails
   }
 }
 
@@ -81,6 +81,6 @@ resource "aws_budgets_budget" "service_budget_cost_email_notification" {
     threshold                  = var.notification_threshold
     threshold_type             = "PERCENTAGE"
     notification_type          = var.notification_type
-    subscriber_email_addresses = [var.notification_emails]
+    subscriber_email_addresses = var.notification_emails
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -69,12 +69,17 @@ variable "notification_type" {
   description = "What kind of budget value to notify on. Can be ACTUAL or FORECASTED"
   type = string
   default = "FORECASTED"
+
+  validation {
+    condition     = var.notification_type == "ACTUAL" || var.notification_type == "FORECASTED"
+    error_message = "Invalid value for notification_type. Please choose either 'ACTUAL' or 'FORECASTED'."
+  }
 }
 
 variable "notification_emails" {
   description = "List of email addresses to send budget notifications too"
-  type    = string
-  default = ""
+  type    = list(string)
+  default = []
 }
 
 variable "cost_type_include_credit" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
+    aws    = ">= 3.52.0"
     random = "3.3.2"
   }
 }


### PR DESCRIPTION
I modify the variable "notification mail" to support a list of string if you want to send to multiple email. 